### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/melihxz/holocompute/security/code-scanning/1](https://github.com/melihxz/holocompute/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, builds, tests, and runs linters, it does not require any write permissions. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` field and before `on:`), which will apply to all jobs in the workflow. No changes to steps or additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
